### PR TITLE
Add install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # LFRD
 LFRD (Pronounced Alfred) is a Lightweight Framework for Rapid Design for personal and commercial static websites.
 
+## Installation
+
+When installing LFRD for the first time, you will need to copy the template files to a root directory so they can be easily obtained at any time. This can be automated by running the `lfrd install .` command in the project directory.
+
 ## Building
 
 Build the app by running `go install .`

--- a/cli/init.go
+++ b/cli/init.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/Rahulio2D/LFRD/helpers"
 	"github.com/spf13/cobra"
@@ -21,7 +22,13 @@ var initCliCommand = &cobra.Command{
 			return
 		}
 
-		templateDirectory := "templates"
+		homeDirectory, err := os.UserHomeDir()
+		if err != nil {
+			fmt.Println("Error finding home directory:", err)
+			return
+		}
+
+		templateDirectory := filepath.Join(homeDirectory, ".lfrd", "templates")
 		if err := helpers.CopyDir(templateDirectory, projectName); err != nil {
 			fmt.Println("Error copying LFRD templates files:", err)
 			return

--- a/cli/install.go
+++ b/cli/install.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Rahulio2D/LFRD/helpers"
+	"github.com/spf13/cobra"
+)
+
+var installCliCommand = &cobra.Command{
+	Use:   "install",
+	Short: "Install the default templates into your home directory",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			fmt.Println("Error: Please provide the full path to the LFRD source directory as an argument.")
+			return
+		}
+
+		lfrdSourceDirectory := args[0]
+
+		homeDirectory, err := os.UserHomeDir()
+		if err != nil {
+			fmt.Println("Error finding home directory:", err)
+			return
+		}
+
+		templateDirectory := filepath.Join(homeDirectory, ".lfrd", "templates")
+		if err := helpers.CopyDir(lfrdSourceDirectory, templateDirectory); err != nil {
+			fmt.Println("Error installing templates:", err)
+			return
+		}
+
+		fmt.Printf("Templates installed to %s\n", templateDirectory)
+	},
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -22,5 +22,6 @@ func Execute() {
 }
 
 func init() {
+	rootCommand.AddCommand(installCliCommand)
 	rootCommand.AddCommand(initCliCommand)
 }


### PR DESCRIPTION
For first time installation we need the template files to be in an easy to access location. This PR adds a simple install command to copy those templates to the user's home directory, and updates the init command to read the templates from those files.

Verified it still builds

<img width="395" height="43" alt="Screenshot 2025-10-05 at 15 25 18" src="https://github.com/user-attachments/assets/9fd93069-7f19-47e9-935f-5a809714110c" />


Now able to run the init command anywhere

<img width="428" height="86" alt="Screenshot 2025-10-05 at 15 26 51" src="https://github.com/user-attachments/assets/86630480-aabc-460a-b07c-8407c296c1c8" />
