### PR TITLE
Add basic build command

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Rahulio2D/LFRD/helpers"
+	"github.com/spf13/cobra"
+)
+
+var buildCliCommand = &cobra.Command{
+	Use:   "build",
+	Short: "Build the website into the docs directory ready for deployment.",
+	Run: func(cmd *cobra.Command, args []string) {
+		workingDirectory, err := os.Getwd()
+		if err != nil {
+			fmt.Println("Error getting working directory:", err)
+			return
+		}
+		destinationDirectory := filepath.Join(workingDirectory, "docs")
+
+		fmt.Println("Building site...")
+		if err := helpers.CopyDir(workingDirectory, destinationDirectory); err != nil {
+			fmt.Println("Error building site:", err)
+			return
+		}
+
+		fmt.Println("✅ Site built successfully!")
+	},
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -24,4 +24,5 @@ func Execute() {
 func init() {
 	rootCommand.AddCommand(installCliCommand)
 	rootCommand.AddCommand(initCliCommand)
+	rootCommand.AddCommand(buildCliCommand)
 }

--- a/helpers/copy.go
+++ b/helpers/copy.go
@@ -22,6 +22,9 @@ func CopyDir(sourceLocation string, destinationLocation string) error {
 		targetPath := filepath.Join(destinationLocation, relPath)
 
 		if fileEntry.IsDir() {
+			if fileEntry.Name() == "docs" {
+				return filepath.SkipDir
+			}
 			return os.MkdirAll(targetPath, 0755)
 		}
 
@@ -29,7 +32,7 @@ func CopyDir(sourceLocation string, destinationLocation string) error {
 	})
 }
 
-func CopyFile(sourceLocation, destinationLocation string) error {
+func CopyFile(sourceLocation string, destinationLocation string) error {
 	in, err := os.Open(sourceLocation)
 	if err != nil {
 		return err


### PR DESCRIPTION
Add a basic build command that copies the template files into a 'docs' folder. This way GitHub pages can read from it and deploy that website.

Right now this is a pure copy, in the next PR I will replace any templated code (i.e. {{ site.title }}) with the actual values so the build can develop a working website. Ideally will also need a way to deploy locally for testing