### PR TITLE
Add serve command for local testing

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -25,4 +25,5 @@ func init() {
 	rootCommand.AddCommand(installCliCommand)
 	rootCommand.AddCommand(initCliCommand)
 	rootCommand.AddCommand(buildCliCommand)
+	rootCommand.AddCommand(serveCliCommand)
 }

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+var serveCliCommand = &cobra.Command{
+	Use:   "serve",
+	Short: "Serve the site locally for testing",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		port := args[0]
+
+		workingDirectory, _ := os.Getwd()
+		siteDirectory := filepath.Join(workingDirectory, "docs")
+
+		fileServer := http.FileServer(http.Dir(siteDirectory))
+		http.Handle("/", fileServer)
+
+		fmt.Println("Serving site at http://localhost:" + port)
+		err := http.ListenAndServe(":"+port, nil)
+		if err != nil {
+			fmt.Println("Error starting server:", err)
+		}
+	},
+}


### PR DESCRIPTION
Add a serve command to setup a simple server for local testing. This command takes in a port number as an argument.

Running the command works

<img width="393" height="36" alt="Screenshot 2025-10-05 at 16 19 58" src="https://github.com/user-attachments/assets/134d0a63-3948-499a-a071-6d7397f5f134" />

Website is rendered at port

<img width="1920" height="570" alt="Screenshot 2025-10-05 at 16 20 16" src="https://github.com/user-attachments/assets/9419333c-7248-4e2d-8df3-394e74912525" />
